### PR TITLE
Fix for last line in editor cut off

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,5 +1,3 @@
 atom-pane atom-text-editor{
-    padding-top:5px;
-    padding-bottom:5px;
     max-height:auto !important;
 }


### PR DESCRIPTION
The padding on `atom-text-editor` was causing the last line of text to be cut off and causing bugs with the scrollbar. Issue #2.
